### PR TITLE
docs: Updated addPluginTemplate example to add filename property

### DIFF
--- a/docs/3.api/5.kit/9.plugins.md
+++ b/docs/3.api/5.kit/9.plugins.md
@@ -223,6 +223,7 @@ export default defineNuxtModule({
 
     addPluginTemplate({
       src: resolve(templatesDir, 'plugin.ejs'),
+      filename: 'plugin.mjs',
       options: {
         ...options,
         ssr: nuxt.options.ssr,


### PR DESCRIPTION
### 🔗 Linked issue

Issue [#24733](https://github.com/nuxt/nuxt/issues/24733)

### ❓ Type of change

- [x ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

According to Daniel's comment [here](https://github.com/nuxt/nuxt/issues/24733#issuecomment-1873912090), A `filename` property with `.mjs` extension is required for `ejs` plugin templates.

### 📝 Checklist

- [ x] I have linked an issue or discussion.
- [ x] I have updated the documentation accordingly.
